### PR TITLE
エラーログ討伐

### DIFF
--- a/src/mincra/magicrod/listener/MagicItemUse.java
+++ b/src/mincra/magicrod/listener/MagicItemUse.java
@@ -270,7 +270,7 @@ public class MagicItemUse extends Skill implements Listener {
 			}
 		}else if((event.getAction().equals(Action.RIGHT_CLICK_AIR)||event.getAction().equals(Action.RIGHT_CLICK_BLOCK))){
 			final Player player = event.getPlayer();
-			if(player.getInventory().getItemInMainHand()!=null&&player.getInventory().getItemInMainHand().getItemMeta().hasLore()==true){
+			if(player.getInventory().getItemInMainHand().getType()!=Material.AIR&&player.getInventory().getItemInMainHand().getItemMeta().hasLore()==true){
 				if(player.hasPermission("mincra.admin.debug")){
 					player.sendMessage(ChatColor.GRAY+"デバッグ02");
 				}

--- a/src/mincra/magicrod/listener/MagicItemUse.java
+++ b/src/mincra/magicrod/listener/MagicItemUse.java
@@ -270,11 +270,11 @@ public class MagicItemUse extends Skill implements Listener {
 			}
 		}else if((event.getAction().equals(Action.RIGHT_CLICK_AIR)||event.getAction().equals(Action.RIGHT_CLICK_BLOCK))){
 			final Player player = event.getPlayer();
-			if(player.getInventory().getItemInMainHand()!=null&&player.getInventory().getItemInMainHand().getItemMeta().hasLore()){
+			if(player.getInventory().getItemInMainHand()!=null&&player.getInventory().getItemInMainHand().getItemMeta().hasLore()==true){
 				if(player.hasPermission("mincra.admin.debug")){
 					player.sendMessage(ChatColor.GRAY+"デバッグ02");
 				}
-				String lore = player.getInventory().getItemInMainHand().getItemMeta().getLore().get(0);
+				String lore =  player.getInventory().getItemInMainHand().getItemMeta().getLore().get(0);
 				lore = ChatColor.stripColor(lore);
 				if(player.hasPermission("mincra.admin.debug")){
 					player.sendMessage(ChatColor.GRAY+lore);


### PR DESCRIPTION
1.8→1.10移行時に量産されていたログ達を討伐
手にアイテムを持っていない状態をNullで表現することができなくなっていた。
空気ブロックを持っている扱い。

おそらく以前は hasLore() のみでtrue扱いになっていたと推測されるが、
hasLore()==true と明示しなければならない仕様に変更されたと思われる。